### PR TITLE
Add functions and aliases

### DIFF
--- a/complements/30-bindings
+++ b/complements/30-bindings
@@ -45,4 +45,20 @@ function change-aws-profile() {
 zle -N change-aws-profile
 bindkey -M viins '^[a' change-aws-profile
 
+# Use fzf to pick files and open them in $EDITOR
+function fzf-open-editor() {
+  local files
+  if [[ $(command -v fd) ]]; then
+    files=$(fd -t f | fzf)
+  else
+    files=$(find . -type f | fzf)
+  fi
+
+  # The prompt redrawing is funky, trying to figure out what works
+  [[ ${files} ]] && echo "${files}" | xargs -o "${EDITOR:-vim}" \
+    && printf "%s\n" " " " " && zle && zle redraw-prompt
+}
+zle -N fzf-open-editor
+bindkey -M viins '^[e' fzf-open-editor
+
 # vim: ft=zsh fdm=manual tabstop=2 softtabstop=2 shiftwidth=2 expandtab:

--- a/complements/30-bindings
+++ b/complements/30-bindings
@@ -34,9 +34,10 @@ zle -N redraw-prompt
 
 # Change exported AWS profile
 function change-aws-profile() {
-  AWS_CREDENTIALS=~/.aws/credentials
-  if [[ -f "${AWS_CREDENTIALS}" ]]; then
-    AWS_PROFILE=$(cat "${AWS_CREDENTIALS}" | grep "\[" | grep -v 'onelogin' \
+  local aws_credentials
+  aws_credentials=~/.aws/credentials
+  if [[ -f "${aws_credentials}" ]]; then
+    AWS_PROFILE=$(cat "${aws_credentials}" | grep "\[" | grep -v 'onelogin' \
       | tr -d "[]" | fzf --height 50%)
     export AWS_PROFILE
     zle && zle redraw-prompt

--- a/complements/40-aliases
+++ b/complements/40-aliases
@@ -16,6 +16,8 @@ alias recomp='rm -f ~/.zcompdump && compinit'
 alias cls='clear'
 alias pacman='pacman --color always'
 alias wic='which'
+alias ewic='edit-which(){ local app=$(which ${@} | awk ''{print $NF}''); \
+  [[ -f ${app} ]] && "${EDITOR:-vim}" "${app}" || echo "${app} not found"; unset -f edit-which; }; edit-which'
 alias yd='youtube-dl'
 alias mkdin='make-folder(){ mkdir "$@" && cd "$_"; unset -f make-folder; }; make-folder'
 alias cd..='cd ..'

--- a/complements/40-aliases
+++ b/complements/40-aliases
@@ -19,7 +19,7 @@ alias wic='which'
 alias ewic='edit-which(){ local app=$(which ${@} | awk ''{print $NF}''); \
   [[ -f ${app} ]] && "${EDITOR:-vim}" "${app}" || echo "${app} not found"; unset -f edit-which; }; edit-which'
 alias yd='youtube-dl'
-alias mkdin='make-folder(){ mkdir "$@" && cd "$_"; unset -f make-folder; }; make-folder'
+alias mkdin='make-dir(){ local dir="$@"; mkdir -p "${dir}" && cd "${dir}"; unset -f make-dir; }; make-dir'
 alias cd..='cd ..'
 alias tree='tree -C'
 alias trel='tree | less'

--- a/runcoms/zshrc
+++ b/runcoms/zshrc
@@ -12,6 +12,9 @@ fi
 # PowerLevel10k prompt config
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 
+# Include hidden files in completions
+_comp_options+=(globdots)
+
 # Aliases, exports, keybindings, and other sourcings
 if [[ -d "${ZDOTDIR:-$HOME}/.zprezto/complements/" ]]; then
   for file in "${ZDOTDIR:-$HOME}/.zprezto/complements/"*; do


### PR DESCRIPTION
* Add ewic alias

Opens in $EDITOR the file found by `which` if it exists. Mnemonic for
edit which.

* Fix issue in mkdin alias

The function was missing the `-p` option to create all the folders.

* Add keybinding to fuzzy pick files and edit them

Allows to edit files picked with `fzf`. Uses `fd` if it's installed,
or `find` as fallback.

* Lint change-aws-profile function

* Enable hidden files in suggestions/completion
